### PR TITLE
mediapipe==0.8.11

### DIFF
--- a/pyVHR_env.yml
+++ b/pyVHR_env.yml
@@ -23,7 +23,7 @@ dependencies:
     - ipython==7.28.0
     - ipywidgets==7.6.5
     - lmfit==1.0.3
-    - mediapipe==0.8.8.1
+    - mediapipe==0.8.11
     - plotly==5.3.1
     - pybdf==0.2.5
     - PySimpleGUI==4.53.0


### PR DESCRIPTION
I have into the same problem as in https://github.com/phuselab/pyVHR/issues/90. And I propose to solve it by updating the dependency mediapipe. 